### PR TITLE
fix: handle event creation with deleted user

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ A list of possible improvements:
 
 - Check password strength in the password validator.
 - Use `redis` to whitelist JWT's (described in the delete endpoint section below).
+- Create architecture diagrams.
+- Document `authentication`, `event`, and `user` flows using `mermaid.js`.
 
 #### POST `/v1/consents/users/registration` (unauthenticated)
 
@@ -225,6 +227,7 @@ Exceptions:
 - A `400` is returned if the request payload does not pass the validation rules. The `id` must be
   either `email_notifications` or `sms_notifications`, and enabled must be a `boolean`.
 - A `401` is returned if the user does not provide a valid JWT in the authorization header.
+- A `422` is returned if the user does not exist.
 - A `500` is returned if an unexpected error occurs.
 
 Sample response:
@@ -272,6 +275,7 @@ event type should be included, e.g. if a user has 5 `email_notifications`, and 2
 Exceptions:
 
 - A `401` is returned if the user does not provide a valid JWT in the authorization header.
+- A `404` is returned if the user does not exist.
 - A `500` is returned if an unexpected error occurs.
 
 Sample response:

--- a/consents.http
+++ b/consents.http
@@ -1,5 +1,5 @@
 @baseUrl = http://localhost:3000/v1/consents
-@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiNjA2MjU4MjUtNGJjNS00YjUzLWJlNmYtNzNkMDkwZjNmMzRiIiwiaWF0IjoxNjM4MTk0NzM4LCJleHAiOjE2MzgxOTU2MzgsImlzcyI6InN1cHBvcnRAZ3Jhbml0ZS5jb20iLCJqdGkiOiJmY2VjOGU3Yi00NzkzLTQ0MTktYWQwNC04OWYwYzllMGJiNGYifQ.4Bn8zC87C6JutvZPyFVXPkkQG456PXuoGHYj9d3F5X0
+@token = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiNjA2MjU4MjUtNGJjNS00YjUzLWJlNmYtNzNkMDkwZjNmMzRiIiwiaWF0IjoxNjM4MTk3MTkzLCJleHAiOjE2MzgxOTgwOTMsImlzcyI6InN1cHBvcnRAZ3Jhbml0ZS5jb20iLCJqdGkiOiI5ZTRmZWU0OC01MDMyLTRkNjktODI0Ni1kODRkY2E2MTdlN2IifQ.PSquNTiSPPpR0n84KgBlB04gU_kfkoyjAm5N1AakQ8I
 
 ########################################################################
 ###########                       AUTH                       ###########
@@ -11,7 +11,7 @@ Accept: application/json
 Content-Type: application/json
 
 {
-  "email": "jane.doe@example.com",
+  "email": "john.doe@example.com",
   "password": "secret"
 }
 
@@ -27,7 +27,7 @@ Authorization: Bearer {{token}}
 
 {
   "id": "email_notifications",
-  "enabled": true
+  "enabled": false
 }
 
 ########################################################################

--- a/packages/backend/svc-consents/src/enum/error-name.enum.ts
+++ b/packages/backend/svc-consents/src/enum/error-name.enum.ts
@@ -6,4 +6,5 @@ export enum ErrorName {
   NotImplemented = 'NotImplemented',
   RequestTimeout = 'RequestTimeout',
   Unauthorized = 'Unauthorized',
+  UnprocessableEntity = 'UnprocessableEntity',
 }

--- a/packages/backend/svc-consents/src/error/index.ts
+++ b/packages/backend/svc-consents/src/error/index.ts
@@ -3,3 +3,4 @@ export { InternalServerError } from './internal-server.error';
 export { NotFoundError } from './not-found.error';
 export { RequestTimeoutError } from './request-timeout.error';
 export { UnauthorizedError } from './unauthorized.error';
+export { UnprocessableEntityError } from './unprocessable-entity.error';

--- a/packages/backend/svc-consents/src/error/unprocessable-entity.error.ts
+++ b/packages/backend/svc-consents/src/error/unprocessable-entity.error.ts
@@ -1,0 +1,44 @@
+import { HttpStatus } from '@nestjs/common';
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ErrorName } from '$/enum/error-name.enum';
+
+import { BaseError } from './base.error';
+
+const DEFAULT_MESSAGE = 'The provided entity could not be processed.';
+
+export class UnprocessableEntityError extends BaseError {
+  @ApiProperty({
+    description: 'The HTTP response code.',
+    example: HttpStatus.UNPROCESSABLE_ENTITY,
+  })
+  declare readonly code: number;
+
+  @ApiProperty({
+    description: 'An array of error details.',
+    example: [],
+    isArray: true,
+  })
+  declare readonly errors: string[] | Record<string, unknown>[];
+
+  @ApiProperty({
+    description: 'The error message.',
+    example: DEFAULT_MESSAGE,
+  })
+  declare readonly message: string;
+
+  @ApiProperty({
+    description: 'The name of the error.',
+    example: ErrorName.UnprocessableEntity,
+  })
+  declare readonly name: string;
+
+  constructor(message?: string, errors?: string[] | Record<string, unknown>[]) {
+    super({
+      code: HttpStatus.UNPROCESSABLE_ENTITY,
+      errors,
+      message: message || DEFAULT_MESSAGE,
+      name: ErrorName.UnprocessableEntity,
+    });
+  }
+}

--- a/packages/backend/svc-consents/src/filters/error.filter.ts
+++ b/packages/backend/svc-consents/src/filters/error.filter.ts
@@ -16,6 +16,7 @@ export class ErrorFilter implements ExceptionFilter {
     403: ErrorName.Forbidden.toString(),
     404: ErrorName.NotFound.toString(),
     408: ErrorName.RequestTimeout.toString(),
+    422: ErrorName.UnprocessableEntity.toString(),
     500: ErrorName.InternalServerError.toString(),
     501: ErrorName.NotImplemented.toString(),
   };


### PR DESCRIPTION
# Overview

If a user with a deleted account still has a valid JWT, we need to check if the user still exists before attempting to save a consent event.

## Checklist

- [x] I have added unit test coverage
- [x] I have added integration test coverage
- [x] I have documented the changes to the source code
