### PR TITLE
test: ensure response headers are set correctly

### DIFF
--- a/packages/backend/svc-consents/test/integration/specs/health.module.spec.ts
+++ b/packages/backend/svc-consents/test/integration/specs/health.module.spec.ts
@@ -23,6 +23,30 @@ describe('Health Module', () => {
       const res = await request(app.getHttpServer()).get(baseUrl).expect(HttpStatus.OK);
       expect(res.body).toMatchObject(healthCheckResponseMock);
     });
+
+    test('[200] => should set headers correctly', async () => {
+      const res = await request(app.getHttpServer()).get(baseUrl).expect(HttpStatus.OK);
+      expect(res.header).toMatchObject({
+        'access-control-allow-credentials': 'true',
+        connection: 'close',
+        'content-length': expect.any(String),
+        'content-security-policy':
+          "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+        'content-type': 'application/json; charset=utf-8',
+        date: expect.any(String),
+        etag: expect.any(String),
+        'expect-ct': 'max-age=0',
+        'referrer-policy': 'no-referrer',
+        'strict-transport-security': 'max-age=15552000; includeSubDomains',
+        vary: 'Origin',
+        'x-content-type-options': 'nosniff',
+        'x-dns-prefetch-control': 'off',
+        'x-download-options': 'noopen',
+        'x-frame-options': 'SAMEORIGIN',
+        'x-permitted-cross-domain-policies': 'none',
+        'x-xss-protection': '0',
+      });
+    });
   });
 
   afterAll(async () => {


### PR DESCRIPTION
# Overview

Adds an integration to ensure the HTTP response headers are set correctly.

## Checklist

- [x] I have added integration test coverage
